### PR TITLE
Make VMChannel honour the DSYNC flag

### DIFF
--- a/native/jni/java-nio/gnu_java_nio_VMChannel.c
+++ b/native/jni/java-nio/gnu_java_nio_VMChannel.c
@@ -1705,7 +1705,8 @@ Java_gnu_java_nio_VMChannel_open (JNIEnv *env,
            | ((mode & CPNIO_APPEND) ? O_APPEND :
               ((nmode == O_WRONLY) ? O_TRUNC : 0))
            | ((mode & CPNIO_EXCL) ? O_EXCL : 0)
-           | ((mode & CPNIO_SYNC) ? O_SYNC : 0));
+           | ((mode & CPNIO_SYNC) ? O_SYNC : 0)
+           | ((mode & CPNIO_DSYNC) ? O_DSYNC : 0));
 
   npath = JCL_jstring_to_cstring (env, path);
 


### PR DESCRIPTION
The native VMChannel open() method ignores the FileChannelImpl.DSYNC mode flag. This flag is used when creating a RandomAccessFile instance with the mode string set to "rwd". Because the flag is ignored, this is equivalent to passing "rw" as the mode string, i.e. updates to the file's content will not be written synchronously to the underlying storage device.

Fix this by making the native VMChannel implementation honour the DSYNC flag.

Fixes #3 (BZ#70659)