### PR TITLE
DecimalFormat: Fix negative suffix when negative pattern is not specified

### DIFF
--- a/java/text/DecimalFormat.java
+++ b/java/text/DecimalFormat.java
@@ -1371,6 +1371,7 @@ public class DecimalFormat extends NumberFormat
     else
       {
         this.positiveSuffix = buffer.toString();
+        this.negativeSuffix = positiveSuffix;
       }
 
     return i;


### PR DESCRIPTION
When a negative pattern is not explicitly defined, DecimalFormat should use the possitive suffix for negative values as well.

Fixes #2 (BZ#70658)