### PR TITLE
Process.destroy: Fix InternalError if native process not found

### DIFF
--- a/native/jni/java-lang/java_lang_VMProcess.c
+++ b/native/jni/java-lang/java_lang_VMProcess.c
@@ -396,7 +396,9 @@ Java_java_lang_VMProcess_nativeKill (JNIEnv * env, jclass clazz, jlong pid)
   int err;
   
   err = cpproc_kill((pid_t) pid, SIGKILL);
-  if (err != 0)
+
+  /* ESRCH (process does not exist) must be handled as success */
+  if (err != 0 && err != ESRCH)
     {
       snprintf (ebuf, sizeof (ebuf), "kill(%ld): %s",
 		(long) pid, cpnative_getErrorString (err));


### PR DESCRIPTION
Process.destroy() may arbitrarily throw InternalError for "recently finished" processes.

Process.destroy() ends up calling VMProcess.nativeKill(), which in turn calls cpproc_kill(). If the process does not exist anymore, cpproc_kill() returns ESRCH, which results in an InternalError being thrown. But this can happen under normal conditions, if the process is reaped just before the call to nativeKill(). This is obviously not expected by user code.

Note that the Javadocs for Process.destroy() have been amended to state that "If the process is not alive, no action is taken."

Fix this by handling ESRCH as success in VMProcess.nativeKill().

Fixes #6 (BZ#108569)