### PR TITLE
Use absolute path for VM source dirs too

### DIFF
--- a/lib/gen-classlist.sh.in
+++ b/lib/gen-classlist.sh.in
@@ -53,14 +53,15 @@ done >> ${top_builddir}/lib/classes.1
 vm_dirlist=`echo "@vm_classes@" | sed -e 's/:/ /g'`
 echo "Adding java source files from VM directory $vm_dirlist"
 for dir in $vm_dirlist; do
-   (cd $dir
+   abs_dir=`cd $dir; pwd`
+   (cd $abs_dir
    for subdir in java javax gnu org com sun; do
       if test -d $subdir; then
 	 @FIND@ $subdir -name '*.java' -print
       fi
    done) | sed -e 's,/\([^/]*\)$, \1,' |
    while read pkg file; do
-      echo $pkg $dir $pkg/$file >> vm.add
+      echo $pkg $abs_dir $pkg/$file >> vm.add
       echo $pkg/$file >> vm.omit
    done
 done


### PR DESCRIPTION
Commit 5281557e introduced the use of absolute pathnames in the output files for gen-classlist.sh but missed adding it for VM dirs.