### PR TITLE
Fix rebuild of vm/reference not being triggered

### DIFF
--- a/lib/gen-classlist.sh.in
+++ b/lib/gen-classlist.sh.in
@@ -125,8 +125,10 @@ done
 if test -n "$vm_omitlist"; then
    cat $vm_omitlist | sed "$sed_omit_hash" > tmp.awk
    cat $vm_omitlist | sed "$sed_omit_main_loop" >> tmp.awk
+   @AWK@ -f tmp.awk < vm.add >> ${top_builddir}/lib/classes.1
+else
+   cat vm.add >> ${top_builddir}/lib/classes.1
 fi
-@AWK@ -f tmp.awk < vm.add >>${top_builddir}/lib/classes.1
 
 rm -f vm.omit vm.add tmp.omit tmp.awk
 


### PR DESCRIPTION
Trying to recompile after modifying vm/reference classes does not correctly trigger a rebuild of those. This seems to be broken since 984a0dd6, which tried to fix 689e97df but missed the case where vm_omitlist is empty, thus not remaking the AWK script and incorrectly using the previous one for VM classes.

This was fixed by calling AWK when vm_omit is not empty, and otherwise (when there are no classes exclussions) adding the whole list of VM classes to the output file.