### PR TITLE
DateFormatSymbols: Fix parsing of strings with a trailing delimiter

### DIFF
--- a/java/text/DateFormatSymbols.java
+++ b/java/text/DateFormatSymbols.java
@@ -325,7 +325,7 @@ public class DateFormatSymbols implements java.io.Serializable, Cloneable
     for (int a = 0; a < bundles.size(); ++a)
       {
         String localeData = bundles.get(a).getString(name);
-        String[] array = FIELD_SEP.split(localeData, size);
+        String[] array = FIELD_SEP.split(localeData, size + 1);
         for (int b = 0; b < data.length; ++b)
           {
             if (array.length > b && array[b] != null && data[b].isEmpty() && !array[b].isEmpty())


### PR DESCRIPTION
Some strings in the locale data seem to contain an extraneous trailing delimiter. This results in an incorrect value for the last parsed symbol (the additional delimiter is returned as part of the symbol).

Fix this by adjusting the 'limit' parameter that is passed to Pattern.split(), so that any additional trailing data is not included in the parsed symbols.

Fixes #5 (BZ#83968)