### PR TITLE
VMDouble: Fix memory leaks in toString() and parseDouble()

### DIFF
--- a/native/fdlibm/dtoa.c
+++ b/native/fdlibm/dtoa.c
@@ -883,16 +883,6 @@ ret1:
   return s0;
 }
 
-static void free_Bigints(struct _Jv_Bigint *p)
-{
-  struct _Jv_Bigint *l = p;
-  while (l)
-    {
-      struct _Jv_Bigint *next = l->_next;
-      free (l);
-      l = next;
-    }
-}
 
 _VOID
 _DEFUN (_dtoa,
@@ -908,22 +898,11 @@ _DEFUN (_dtoa,
 {
   struct _Jv_reent reent;
   char *p;
-  int i;
 
   memset (&reent, 0, sizeof reent);
 
   p = _dtoa_r (&reent, _d, mode, ndigits, decpt, sign, rve, float_type);
   strcpy (buf, p);
 
-  for (i = 0; i < reent._max_k; ++i)
-    {
-      free_Bigints (reent._freelist[i]);
-    }
-  if (reent._freelist)
-    free (reent._freelist);
-
-  if (reent._result)
-    free (reent._result);
-
-  free_Bigints (reent._p5s);
+  reclaim_reent (&reent);
 }

--- a/native/fdlibm/dtoa.c
+++ b/native/fdlibm/dtoa.c
@@ -904,5 +904,5 @@ _DEFUN (_dtoa,
   p = _dtoa_r (&reent, _d, mode, ndigits, decpt, sign, rve, float_type);
   strcpy (buf, p);
 
-  reclaim_reent (&reent);
+  _reclaim_reent (&reent);
 }

--- a/native/fdlibm/dtoa.c
+++ b/native/fdlibm/dtoa.c
@@ -883,6 +883,16 @@ ret1:
   return s0;
 }
 
+static void free_Bigints(struct _Jv_Bigint *p)
+{
+  struct _Jv_Bigint *l = p;
+  while (l)
+    {
+      struct _Jv_Bigint *next = l->_next;
+      free (l);
+      l = next;
+    }
+}
 
 _VOID
 _DEFUN (_dtoa,
@@ -905,16 +915,15 @@ _DEFUN (_dtoa,
   p = _dtoa_r (&reent, _d, mode, ndigits, decpt, sign, rve, float_type);
   strcpy (buf, p);
 
-  for (i = 0; i < reent._result_k; ++i)
+  for (i = 0; i < reent._max_k; ++i)
     {
-      struct _Jv_Bigint *l = reent._freelist[i];
-      while (l)
-	{
-	  struct _Jv_Bigint *next = l->_next;
-	  free (l);
-	  l = next;
-	}
+      free_Bigints (reent._freelist[i]);
     }
   if (reent._freelist)
     free (reent._freelist);
+
+  if (reent._result)
+    free (reent._result);
+
+  free_Bigints (reent._p5s);
 }

--- a/native/fdlibm/mprec.c
+++ b/native/fdlibm/mprec.c
@@ -110,7 +110,7 @@ mprec_calloc (void *ignore, size_t x1, size_t x2)
 }
 
 void
-reclaim_reent (struct _reent *ptr)
+_reclaim_reent (struct _reent *ptr)
 {
   if (_REENT_MP_FREELIST(ptr))
     {

--- a/native/fdlibm/mprec.c
+++ b/native/fdlibm/mprec.c
@@ -95,6 +95,7 @@
 
 #define _REENT_CHECK_MP(x)
 #define _REENT_MP_FREELIST(x) ((x)->_freelist)
+#define _REENT_MP_RESULT(x) ((x)->_result)
 #define _REENT_MP_P5S(x) ((x)->_p5s)
 
 typedef unsigned long __ULong;
@@ -106,6 +107,42 @@ mprec_calloc (void *ignore, size_t x1, size_t x2)
   char *result = (char *) malloc (x1 * x2);
   memset (result, 0, x1 * x2);
   return result;
+}
+
+void
+reclaim_reent (struct _reent *ptr)
+{
+  if (_REENT_MP_FREELIST(ptr))
+    {
+      int i;
+      for (i = 0; i < ptr->_max_k; i++)
+        {
+          struct _Bigint *thisone, *nextone;
+
+          nextone = _REENT_MP_FREELIST(ptr)[i];
+          while (nextone)
+            {
+              thisone = nextone;
+              nextone = nextone->_next;
+              free (thisone);
+            }
+        }
+
+      free (_REENT_MP_FREELIST(ptr));
+    }
+  if (_REENT_MP_RESULT(ptr))
+    free (_REENT_MP_RESULT(ptr));
+  if (_REENT_MP_P5S(ptr))
+    {
+      struct _Bigint *thisone, *nextone;
+      nextone = _REENT_MP_P5S(ptr);
+      while (nextone)
+       {
+         thisone = nextone;
+         nextone = nextone->_next;
+         free (thisone);
+       }
+    }
 }
 
 _Bigint *

--- a/native/fdlibm/mprec.h
+++ b/native/fdlibm/mprec.h
@@ -316,8 +316,6 @@ struct _Jv_reent
   int _max_k;
 };
 
-void _EXFUN(reclaim_reent, (struct _Jv_reent *ptr));
-
 
 typedef struct _Jv_Bigint _Jv_Bigint;
 
@@ -345,6 +343,7 @@ typedef struct _Jv_Bigint _Jv_Bigint;
 #define _dtoa _Jv_dtoa
 #define _dtoa_r _Jv_dtoa_r
 #define _strtod_r _Jv_strtod_r
+#define _reclaim_reent _Jv_reclaim_reent
 
 extern double _EXFUN(_strtod_r, (struct _Jv_reent *ptr, const char *s00, char **se));
 extern char* _EXFUN(_dtoa_r, (struct _Jv_reent *ptr, double d,
@@ -352,6 +351,7 @@ extern char* _EXFUN(_dtoa_r, (struct _Jv_reent *ptr, double d,
 			      char **rve, int float_type));
 void _EXFUN(_dtoa, (double d, int mode, int ndigits, int *decpt, int *sign,
 		    char **rve, char *buf, int float_type));
+void _EXFUN(_reclaim_reent, (struct _Jv_reent *ptr));
 
 double 		_EXFUN(ulp,(double x));
 double		_EXFUN(b2d,(_Jv_Bigint *a , int *e));

--- a/native/fdlibm/mprec.h
+++ b/native/fdlibm/mprec.h
@@ -316,6 +316,8 @@ struct _Jv_reent
   int _max_k;
 };
 
+void _EXFUN(reclaim_reent, (struct _Jv_reent *ptr));
+
 
 typedef struct _Jv_Bigint _Jv_Bigint;
 

--- a/native/jni/java-lang/java_lang_VMDouble.c
+++ b/native/jni/java-lang/java_lang_VMDouble.c
@@ -158,6 +158,17 @@ Java_java_lang_VMDouble_longBitsToDouble
   return val.d;
 }
 
+static void free_Bigints(struct _Jv_Bigint *p)
+{
+  struct _Jv_Bigint *l = p;
+  while (l)
+    {
+      struct _Jv_Bigint *next = l->_next;
+      free (l);
+      l = next;
+    }
+}
+
 /**
  * Parse a double from a char array.
  */
@@ -167,7 +178,7 @@ parseDoubleFromChars(JNIEnv * env, const char * buf)
   char *endptr;
   jdouble val = 0.0;
   const char *p = buf, *end, *last_non_ws, *temp;
-  int ok = 1;
+  int i, ok = 1;
 
 #ifdef DEBUG
   fprintf (stderr, "java.lang.VMDouble.parseDouble (%s)\n", buf);
@@ -223,6 +234,18 @@ parseDoubleFromChars(JNIEnv * env, const char * buf)
       memset (&reent, 0, sizeof reent);
 
       val = _strtod_r (&reent, p, &endptr);
+
+      for (i = 0; i < reent._max_k; ++i)
+        {
+          free_Bigints (reent._freelist[i]);
+        }
+      if (reent._freelist)
+        free (reent._freelist);
+
+      if (reent._result)
+        free (reent._result);
+
+      free_Bigints (reent._p5s);
 
 #ifdef DEBUG
       fprintf (stderr, "java.lang.VMDouble.parseDouble val = %g\n", val);

--- a/native/jni/java-lang/java_lang_VMDouble.c
+++ b/native/jni/java-lang/java_lang_VMDouble.c
@@ -224,7 +224,7 @@ parseDoubleFromChars(JNIEnv * env, const char * buf)
 
       val = _strtod_r (&reent, p, &endptr);
 
-      reclaim_reent (&reent);
+      _reclaim_reent (&reent);
 
 #ifdef DEBUG
       fprintf (stderr, "java.lang.VMDouble.parseDouble val = %g\n", val);

--- a/native/jni/java-lang/java_lang_VMDouble.c
+++ b/native/jni/java-lang/java_lang_VMDouble.c
@@ -158,17 +158,6 @@ Java_java_lang_VMDouble_longBitsToDouble
   return val.d;
 }
 
-static void free_Bigints(struct _Jv_Bigint *p)
-{
-  struct _Jv_Bigint *l = p;
-  while (l)
-    {
-      struct _Jv_Bigint *next = l->_next;
-      free (l);
-      l = next;
-    }
-}
-
 /**
  * Parse a double from a char array.
  */
@@ -178,7 +167,7 @@ parseDoubleFromChars(JNIEnv * env, const char * buf)
   char *endptr;
   jdouble val = 0.0;
   const char *p = buf, *end, *last_non_ws, *temp;
-  int i, ok = 1;
+  int ok = 1;
 
 #ifdef DEBUG
   fprintf (stderr, "java.lang.VMDouble.parseDouble (%s)\n", buf);
@@ -235,17 +224,7 @@ parseDoubleFromChars(JNIEnv * env, const char * buf)
 
       val = _strtod_r (&reent, p, &endptr);
 
-      for (i = 0; i < reent._max_k; ++i)
-        {
-          free_Bigints (reent._freelist[i]);
-        }
-      if (reent._freelist)
-        free (reent._freelist);
-
-      if (reent._result)
-        free (reent._result);
-
-      free_Bigints (reent._p5s);
+      reclaim_reent (&reent);
 
 #ifdef DEBUG
       fprintf (stderr, "java.lang.VMDouble.parseDouble val = %g\n", val);


### PR DESCRIPTION
Function _dtoa from fdlibm was failing to release memory allocated during double->string conversion. A similar problem was also present in function parseDoubleFromChars in java_lang_VMDouble.c

This caused leaks in VMDouble.toString() and .parseDouble()

Fixes #34 (BZ#29263)