### PR TITLE
Avoid closing unrelated descriptors when spawning fails early

### DIFF
--- a/native/jni/java-lang/java_lang_VMProcess.c
+++ b/native/jni/java-lang/java_lang_VMProcess.c
@@ -126,7 +126,7 @@ Java_java_lang_VMProcess_nativeSpawn (JNIEnv * env, jobject this,
 				      jobjectArray envArray, jobject dirFile,
 				      jboolean redirect)
 {
-  int fds[CPIO_EXEC_NUM_PIPES];
+  int fds[CPIO_EXEC_NUM_PIPES] = { -1, -1, -1 };
   jobject streams[CPIO_EXEC_NUM_PIPES] = { NULL, NULL, NULL };
   jobject dirString = NULL;
   char **newEnviron = NULL;


### PR DESCRIPTION
VMProcess.nativeSpawn() can fail before calling cpproc_forkAndExec() (null/empty command array, string extraction failure, malloc failure). Since fds[] is not initialized, the cleanup path could end up closing up to three arbitrary live descriptors.

Initialize every descriptor to -1 at declaration so all early failure paths are safe.