### PR TITLE
cpproc.c: Reorganize to isolate code running in the child

### DIFF
--- a/native/jni/native-lib/cpproc.c
+++ b/native/jni/native-lib/cpproc.c
@@ -53,6 +53,164 @@ exception statement from your version. */
 #define PATH_MAX 4096
 #endif
 
+static void close_all_fds(int *fds, int numFds);
+static void child_process(char * const *commandLine,
+			  char * const *newEnviron,
+			  int *local_fds, int pipe_count, int *fail_fds,
+			  const char *path, char **sh_argv, const char *wd);
+
+int cpproc_forkAndExec (char * const *commandLine, char * const * newEnviron,
+			int *fds, int pipe_count, pid_t *out_pid, const char *wd)
+{
+  int local_fds[6];
+  int fail_fds[2];
+  const char *path;
+  char **sh_argv;
+  int errnum;
+  ssize_t n;
+  int argc;
+  int i;
+  pid_t pid;
+
+  /* Initialize the output fds so that the caller sees no garbage in
+     them if we return with an error, or in the unused stderr entry
+     when redirection is requested */
+  for (i = 0; i < CPIO_EXEC_NUM_PIPES; i++)
+    fds[i] = -1;
+
+  /* Preallocate the buffer used by cp_execvpe in the child: after the
+     fork of a multi-threaded process only async-signal-safe operations
+     may be executed, so no malloc there */
+  path = getenv("PATH");
+  if (path == NULL)
+    path = "/bin:/usr/bin";
+  for (argc = 0; commandLine[argc] != NULL; argc++)
+    ;
+  sh_argv = malloc((argc + 2) * sizeof(char *));
+  if (sh_argv == NULL)
+    return ENOMEM;
+
+  for (i = 0; i < (pipe_count * 2); i += 2)
+    {
+      if (pipe(&local_fds[i]) < 0)
+	{
+	  int err = errno;
+
+	  close_all_fds(local_fds, i);
+	  free(sh_argv);
+
+	  return err;
+	}
+    }
+
+  /* Extra pipe used by the child to report a failed chdir or exec to
+     the parent. On success the exec closes the write end (FD_CLOEXEC)
+     and the parent reads EOF. */
+  if (pipe(fail_fds) < 0)
+    {
+      int err = errno;
+
+      close_all_fds(local_fds, pipe_count * 2);
+      free(sh_argv);
+
+      return err;
+    }
+
+  pid = fork();
+
+  switch (pid)
+    {
+    case 0:
+      child_process(commandLine, newEnviron, local_fds, pipe_count,
+		    fail_fds, path, sh_argv, wd);
+      /* child_process() does not return. */
+      _exit(127);
+
+    case -1:
+      {
+	int err = errno;
+
+	close_all_fds(local_fds, pipe_count * 2);
+	close(fail_fds[0]);
+	close(fail_fds[1]);
+	free(sh_argv);
+	return err;
+      }
+    default:
+      free(sh_argv);
+      close(fail_fds[1]);
+
+      /* Wait for the outcome of the exec: EOF if it succeeded, the
+	 child's errno if not */
+      do
+	{
+	  n = read(fail_fds[0], &errnum, sizeof(errnum));
+	}
+      while (n < 0 && errno == EINTR);
+      close(fail_fds[0]);
+
+      if (n != 0)
+	{
+	  int status;
+
+	  if (n != (ssize_t) sizeof(errnum))
+	    errnum = EIO;
+
+	  /* The child exited without exec'ing; reap it */
+	  while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+	    ;
+
+	  close_all_fds(local_fds, pipe_count * 2);
+	  return errnum;
+	}
+
+      close(local_fds[0]);
+      close(local_fds[3]);
+      if (pipe_count == 3)
+	close(local_fds[5]);
+
+      fds[0] = local_fds[1];
+      fds[1] = local_fds[2];
+      if (pipe_count == 3)
+	fds[2] = local_fds[4];
+      *out_pid = pid;
+      return 0;
+    }
+
+  /* keep compiler happy */
+
+  return 0;
+}
+
+int cpproc_waitpid (pid_t pid, int *status, pid_t *outpid, int options)
+{
+  pid_t wp = waitpid(pid, status, options);
+
+  if (wp < 0)
+    return errno;
+
+  *outpid = wp;
+  return 0;
+}
+
+int cpproc_kill (pid_t pid, int signal)
+{
+  if (kill(pid, signal) < 0)
+    return errno;
+
+  return 0;
+}
+
+
+/* Child-side implementation.
+
+   Everything below this point may run in the child of a fork() of a
+   multi-threaded process, so it should only use async-signal-safe
+   operations. Avoid malloc and functions that may take locks. Any
+   buffers that require allocation must be preallocated by the parent
+   and passed in. */
+
+/* Also used by the parent. */
 static void close_all_fds(int *fds, int numFds)
 {
   int i;
@@ -100,9 +258,7 @@ static void cp_execvpe(const char *file, char * const *argv,
 		       char * const *envp, const char *path,
 		       char **sh_argv)
 {
-  /* - This runs in the child of a fork of a multi-threaded process,
-       so it may only execute async-signal-safe operations.
-     - If execve fails with ENOEXEC, we assume it is a script with +x
+  /* - If execve fails with ENOEXEC, we assume it is a script with +x
        permission (otherwise we would have seen EACCES) but without a
        shebang line, and execute it via /bin/sh, as execvp would do.
        The fallback is implemented explicitly because execve does not
@@ -186,163 +342,34 @@ static void cp_execvpe(const char *file, char * const *argv,
     errno = EACCES;
 }
 
-int cpproc_forkAndExec (char * const *commandLine, char * const * newEnviron,
-			int *fds, int pipe_count, pid_t *out_pid, const char *wd)
+static void child_process(char * const *commandLine,
+			  char * const *newEnviron,
+			  int *local_fds, int pipe_count, int *fail_fds,
+			  const char *path, char **sh_argv, const char *wd)
 {
-  int local_fds[6];
-  int fail_fds[2];
-  const char *path;
-  char **sh_argv;
   int errnum;
-  ssize_t n;
-  int argc;
-  int i;
-  pid_t pid;
 
-  /* Initialize the output fds so that the caller sees no garbage in
-     them if we return with an error, or in the unused stderr entry
-     when redirection is requested */
-  for (i = 0; i < CPIO_EXEC_NUM_PIPES; i++)
-    fds[i] = -1;
+  close(fail_fds[0]);
+  if (fcntl(fail_fds[1], F_SETFD, FD_CLOEXEC) < 0)
+    goto child_error;
 
-  /* Preallocate the buffer used by cp_execvpe in the child: after the
-     fork of a multi-threaded process only async-signal-safe operations
-     may be executed, so no malloc there */
-  path = getenv("PATH");
-  if (path == NULL)
-    path = "/bin:/usr/bin";
-  for (argc = 0; commandLine[argc] != NULL; argc++)
+  dup2(local_fds[0], 0);
+  dup2(local_fds[3], 1);
+  if (pipe_count == 3)
+    dup2(local_fds[5], 2);
+  else
+    dup2(1, 2);
+
+  close_all_fds(local_fds, pipe_count * 2);
+
+  if (wd == NULL || chdir(wd) == 0)
+    cp_execvpe(commandLine[0], commandLine, newEnviron, path, sh_argv);
+
+ child_error:
+  /* The fcntl, chdir or exec failed; send our errno to the parent */
+  errnum = errno;
+  while (write(fail_fds[1], &errnum, sizeof(errnum)) < 0
+	 && errno == EINTR)
     ;
-  sh_argv = malloc((argc + 2) * sizeof(char *));
-  if (sh_argv == NULL)
-    return ENOMEM;
-
-  for (i = 0; i < (pipe_count * 2); i += 2)
-    {
-      if (pipe(&local_fds[i]) < 0)
-	{
-	  int err = errno;
-
-	  close_all_fds(local_fds, i);
-	  free(sh_argv);
-
-	  return err;
-	}
-    }
-
-  /* Extra pipe used by the child to report a failed chdir or exec to
-     the parent. On success the exec closes the write end (FD_CLOEXEC)
-     and the parent reads EOF. */
-  if (pipe(fail_fds) < 0)
-    {
-      int err = errno;
-
-      close_all_fds(local_fds, pipe_count * 2);
-      free(sh_argv);
-
-      return err;
-    }
-
-  pid = fork();
-
-  switch (pid)
-    {
-    case 0:
-      close(fail_fds[0]);
-      if (fcntl(fail_fds[1], F_SETFD, FD_CLOEXEC) < 0)
-	goto child_error;
-
-      dup2(local_fds[0], 0);
-      dup2(local_fds[3], 1);
-      if (pipe_count == 3)
-	dup2(local_fds[5], 2);
-      else
-	dup2(1, 2);
-
-      close_all_fds(local_fds, pipe_count * 2);
-
-      if (wd == NULL || chdir(wd) == 0)
-	cp_execvpe(commandLine[0], commandLine, newEnviron, path, sh_argv);
-
-    child_error:
-      /* The fcntl, chdir or exec failed; send our errno to the parent */
-      errnum = errno;
-      while (write(fail_fds[1], &errnum, sizeof(errnum)) < 0
-	     && errno == EINTR)
-	;
-      _exit(127);
-
-    case -1:
-      {
-	int err = errno;
-
-	close_all_fds(local_fds, pipe_count * 2);
-	close(fail_fds[0]);
-	close(fail_fds[1]);
-	free(sh_argv);
-	return err;
-      }
-    default:
-      free(sh_argv);
-      close(fail_fds[1]);
-
-      /* Wait for the outcome of the exec: EOF if it succeeded, the
-	 child's errno if not */
-      do
-	{
-	  n = read(fail_fds[0], &errnum, sizeof(errnum));
-	}
-      while (n < 0 && errno == EINTR);
-      close(fail_fds[0]);
-
-      if (n != 0)
-	{
-	  int status;
-
-	  if (n != (ssize_t) sizeof(errnum))
-	    errnum = EIO;
-
-	  /* The child exited without exec'ing; reap it */
-	  while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
-	    ;
-
-	  close_all_fds(local_fds, pipe_count * 2);
-	  return errnum;
-	}
-
-      close(local_fds[0]);
-      close(local_fds[3]);
-      if (pipe_count == 3)
-	close(local_fds[5]);
-
-      fds[0] = local_fds[1];
-      fds[1] = local_fds[2];
-      if (pipe_count == 3)
-	fds[2] = local_fds[4];
-      *out_pid = pid;
-      return 0;
-    }
-
-  /* keep compiler happy */
-
-  return 0;
-}
-
-int cpproc_waitpid (pid_t pid, int *status, pid_t *outpid, int options)
-{
-  pid_t wp = waitpid(pid, status, options);
-
-  if (wp < 0)
-    return errno;
-
-  *outpid = wp;
-  return 0;
-}
-
-int cpproc_kill (pid_t pid, int signal)
-{
-  if (kill(pid, signal) < 0)
-    return errno;
-
-  return 0;
+  _exit(127);
 }


### PR DESCRIPTION
Extract the child branch of cpproc_forkAndExec() into a static child_process() helper. Move it into a dedicated section, along with any functions that may run in the forked child, and document the async-signal-safety constraints for this code.

There are no functional changes. All helpers remain static within the file; no new exported symbols are introduced.