### PR TITLE
Preserve exit values above 127 when reaping children

### DIFF
--- a/native/jni/java-lang/java_lang_VMProcess.c
+++ b/native/jni/java-lang/java_lang_VMProcess.c
@@ -362,7 +362,7 @@ Java_java_lang_VMProcess_nativeReap (JNIEnv * env, jclass clazz)
 
   /* Get exit code; for signal termination return negative signal value XXX */
   if (WIFEXITED (status))
-    status = (jint) (jbyte) WEXITSTATUS (status);
+    status = (jint) WEXITSTATUS (status);
   else if (WIFSIGNALED (status))
     status = -(jint) WTERMSIG (status);
   else


### PR DESCRIPTION
When a child process exits with a code above 127, Process.waitFor() and Process.exitValue() return a negative number. This happens because VMProcess.nativeReap() incorrectly casts WEXITSTATUS() to jbyte (which is signed) before publishing it, so e.g. exit code 128 is reported as -128 and 250 as -6.

In addition, the incorrect values can be mistaken for signal deaths, which Classpath reports as the negative signal number (so -6 is what is reported when a child is killed by SIGABRT).

Fix by removing the incorrect jbyte cast.

Fixes #54 (BZ#126651)